### PR TITLE
Nanode link to address when sending to a recipient address

### DIFF
--- a/nano_tipper_z.py
+++ b/nano_tipper_z.py
@@ -461,7 +461,7 @@ def handle_send_nano(message, parsed_text, comment_or_message):
         if user_or_address == 'user':
             return "Sent ```%s Nano``` to /u/%s -- [Transaction on Nanode](https://www.nanode.co/block/%s)" % (amount / 10 ** 30, recipient_username, sent['hash'])
         else:
-            return "Sent ```%s Nano``` to %s -- [Transaction on Nanode](https://www.nanode.co/block/%s)" % (amount / 10 ** 30, recipient_address, sent['hash'])
+            return "Sent ```%s Nano``` to [%s](https://www.nanode.co/account/%s) -- [Transaction on Nanode](https://www.nanode.co/block/%s)" % (amount / 10 ** 30, recipient_address, recipient_address, sent['hash'])
 
     elif recipient_address:
         # or if we have an address but no account, just send
@@ -477,7 +477,7 @@ def handle_send_nano(message, parsed_text, comment_or_message):
         val = (sent['hash'], entry_id)
         mycursor.execute(sql, val)
         mydb.commit()
-        return "Sent ```%s Nano``` to %s. -- [Transaction on Nanode](https://www.nanode.co/block/%s)" % (amount/ 10 ** 30, recipient_address, sent['hash'])
+        return "Sent ```%s Nano``` to [%s](https://www.nanode.co/account/%s). -- [Transaction on Nanode](https://www.nanode.co/block/%s)" % (amount/ 10 ** 30, recipient_address, recipient_address, sent['hash'])
     else:
         # create a new account for redditor
         recipient_address = add_new_account(recipient_username)


### PR DESCRIPTION
Hi, I run [u/NanodeLinkBot](https://www.reddit.com/user/Nanodelinkbot), a bot that replies to nano address with a link to a block explorer page for any mentioned addresses or blocks. 

I noticed that your bot can send nano to any address from comments ([example](https://www.reddit.com/r/nano_tipper_z/comments/akq48r/new_db/efaomce/)). In that example, my bot would reply to both those comments since they both mention nano addresses. I think having multiple bots replying to a single tipping comment and bots replying to bots might be a bit too much, so I have changed my bot to ignore comments starting with `!nano_tip` and ignore comments by your bot, `u/nano_tipper_z`.

However, I think having a block explorer link to the nano address would still be useful, so I made this pull request to add a link to the address on a block explorer when your bot replies. The reply will be the same, but with the address hyperlinked to nanode.