### PR TITLE
Reply directly to PMs

### DIFF
--- a/src/message_functions.py
+++ b/src/message_functions.py
@@ -143,7 +143,13 @@ def handle_message(message):
         return None
     message_recipient = str(message.author)
     message_text = response + COMMENT_FOOTER
-    send_pm(message_recipient, subject, message_text, bypass_opt_out=True)
+    send_pm(
+        message_recipient,
+        subject,
+        message_text,
+        bypass_opt_out=True,
+        message_id=message.name,
+    )
 
 
 def handle_percentage(message):

--- a/src/messenger.py
+++ b/src/messenger.py
@@ -6,14 +6,22 @@ while True:
     MYCURSOR.execute(sql)
     results = MYCURSOR.fetchall()
     MYDB.commit()
+
     for result in results:
-        LOGGER.info("%s %s %s" % (result[1], result[2], repr(result[3])[:50]))
+        LOGGER.info(
+            "%s %s %s %s" % (result[1], result[2], result[4], repr(result[3])[:50])
+        )
 
-        try:
+        # try:
+        # find the message to reply to it.
+        if result[4] is not None:
+            msg = REDDIT.inbox.message(result[4].replace("t4_", ""))
+            msg.reply(str(result[3]))
+        # if it was a comment, create a new message
+        else:
             REDDIT.redditor(str(result[1])).message(str(result[2]), str(result[3]))
-        except:
-
-            pass
+        # except:
+        #     pass
         sql = "DELETE FROM messages WHERE id = %s"
         val = (result[0],)
         MYCURSOR.execute(sql, val)

--- a/src/tipper_functions.py
+++ b/src/tipper_functions.py
@@ -223,7 +223,7 @@ def update_history_notes(entry_id, text):
     MYDB.commit()
 
 
-def send_pm(recipient, subject, body, bypass_opt_out=False):
+def send_pm(recipient, subject, body, bypass_opt_out=False, message_id=None):
     opt_in = True
     # If there is not a bypass to opt in, check the status
     if not bypass_opt_out:
@@ -234,8 +234,11 @@ def send_pm(recipient, subject, body, bypass_opt_out=False):
 
     # if the user has opted in, or if there is an override to send the PM even if they have not
     if opt_in or not bypass_opt_out:
-        sql = "INSERT INTO messages (username, subject, message) VALUES (%s, %s, %s)"
-        val = (recipient, subject, body)
+        sql = (
+            "INSERT INTO messages (username, subject, message, message_id)"
+            " VALUES (%s, %s, %s, %s)"
+        )
+        val = (recipient, subject, body, message_id)
         MYCURSOR.execute(sql, val)
         MYDB.commit()
 

--- a/src/tipper_sql.py
+++ b/src/tipper_sql.py
@@ -57,7 +57,8 @@ def init_messages():
         "id INT AUTO_INCREMENT PRIMARY KEY, "
         "username VARCHAR(255), "
         "subject VARCHAR(255), "
-        "message VARCHAR(5000) "
+        "message VARCHAR(5000), "
+        "message_id VARCHAR(5000)"
         ")"
     )
     MYDB.commit()
@@ -397,6 +398,12 @@ def migrate_add_subreddit_18():
     sql = "ALTER TABLE history ADD subreddit VARCHAR(255)"
     MYCURSOR.execute(sql)
     init_returns()
+    MYDB.commit()
+
+
+def migrate_reply_19():
+    sql = "ALTER TABLE messages ADD message_id VARCHAR(255)"
+    MYCURSOR.execute(sql)
     MYDB.commit()
 
 


### PR DESCRIPTION
Fixes #61 .

This enables new functionality so that PMs to the bot are responded to directly, rather than creating a new PM.